### PR TITLE
fix: use a proper way to set Timestamp param

### DIFF
--- a/dist/base/BaseClient.js
+++ b/dist/base/BaseClient.js
@@ -8,13 +8,8 @@ const getSignedParams = require('../lib/sign.js').getSignedParams;
 
 const fetch = require('../lib/fetch.js');
 
-const dayjs = require('dayjs');
-
-const utc = require('dayjs/plugin/utc.js');
-
 const qs = require('qs');
 
-dayjs.extend(utc);
 module.exports = class BaseClient {
   constructor(clientConfig) {
     _defineProperty(this, "_baseConfig", {});
@@ -43,7 +38,7 @@ module.exports = class BaseClient {
       Service: this._baseConfig.config.credentials.service,
       Action: apiAction,
       Version: apiConfig.config.query.Version,
-      Timestamp: dayjs().utc().format('YYYY-MM-DDThh:mm:ss') + 'Z',
+      Timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
       SignatureVersion: '1.0',
       SignatureMethod: 'HMAC-SHA256',
       Region: this.region || this._baseConfig.config.credentials.region

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "abort-controller": "^3.0.0",
                 "core-js": "^3.6.5",
                 "crypto-js": "^4.1.1",
-                "dayjs": "^1.10.7",
                 "node-fetch": "^2.6.7",
                 "qs": "^6.10.3"
             },
@@ -2222,11 +2221,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmmirror.com/crypto-js/-/crypto-js-4.1.1.tgz",
             "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-        },
-        "node_modules/dayjs": {
-            "version": "1.10.8",
-            "resolved": "https://registry.npmmirror.com/dayjs/-/dayjs-1.10.8.tgz",
-            "integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow=="
         },
         "node_modules/debug": {
             "version": "4.3.3",
@@ -5477,11 +5471,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmmirror.com/crypto-js/-/crypto-js-4.1.1.tgz",
             "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-        },
-        "dayjs": {
-            "version": "1.10.8",
-            "resolved": "https://registry.npmmirror.com/dayjs/-/dayjs-1.10.8.tgz",
-            "integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow=="
         },
         "debug": {
             "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
         "abort-controller": "^3.0.0",
         "core-js": "^3.6.5",
         "crypto-js": "^4.1.1",
-        "dayjs": "^1.10.7",
         "node-fetch": "^2.6.7",
         "qs": "^6.10.3"
     },

--- a/src/base/BaseClient.js
+++ b/src/base/BaseClient.js
@@ -1,10 +1,6 @@
 const getSignedParams = require('../lib/sign.js').getSignedParams
 const fetch = require('../lib/fetch.js')
-const dayjs = require('dayjs')
-const utc = require('dayjs/plugin/utc.js')
 const qs = require('qs')
-
-dayjs.extend(utc)
 
 module.exports = class BaseClient {
     _baseConfig = {}
@@ -32,7 +28,7 @@ module.exports = class BaseClient {
             Service: this._baseConfig.config.credentials.service,
             Action: apiAction,
             Version: apiConfig.config.query.Version,
-            Timestamp: dayjs().utc().format('YYYY-MM-DDThh:mm:ss')+'Z',
+            Timestamp: (new Date()).toISOString().replace(/\.\d{3}Z$/, 'Z'),
             SignatureVersion: '1.0',
             SignatureMethod: 'HMAC-SHA256',
             Region: this.region || this._baseConfig.config.credentials.region,


### PR DESCRIPTION
problems:

1. The original code uses the wrong format 'hh' to present a 24-hour format date-time string, which is incorrect.  
**It should be 'HH'**.
3. Since the `dayjs` module is the only used here, there's a simpler way to present the whole acceptable  Timestamp string: `(new Date()).toISOString()`, then remove the millisecond part by `.replace(/\.\d{3}Z$/, '')`.  
**So I removed this dependency, and use `(new Date()).toISOString().replace(/\.\d{3}Z$/, 'Z')` here.**

by the way:

when I run `npm run build`, there're other files and directories has been changed local on my disk, but I've just pick the files about I've modified to push.

Maybe the whole npm package should be upgraded completely by you, the maintainers. :-)